### PR TITLE
fixed sensitivity of swipe gestures

### DIFF
--- a/src/jquery.jcarousel-swipe.js
+++ b/src/jquery.jcarousel-swipe.js
@@ -64,12 +64,15 @@
                     event.preventDefault();
                 }
 
-                if (Math.abs(startTouch[yKey] - currentTouch[yKey]) > 10 && !started) {
+				var xDiff = Math.abs(startTouch[xKey] - currentTouch[xKey]);
+				var yDiff = Math.abs(startTouch[yKey] - currentTouch[yKey]);
+				
+                if (yDiff > 10 && yDiff > xDiff && !started) {
                     $(document).off('touchmove.jcarouselSwipe mousemove.jcarouselSwipe');
                     return;
                 }
 
-                if (!animated && Math.abs(startTouch[xKey] - currentTouch[xKey]) > 10) {
+                if (!animated && xDiff > 10 && xDiff > yDiff) {
                     delta = startTouch[xKey] - currentTouch[xKey];
 
                     if (!started) {

--- a/src/jquery.jcarousel-swipe.js
+++ b/src/jquery.jcarousel-swipe.js
@@ -59,20 +59,19 @@
                 var delta, newLT, itemsOption;
                 event = event.originalEvent || event || window.event;
                 currentTouch = getTouches(event);
+                var xDiff = Math.abs(startTouch[xKey] - currentTouch[xKey]);
+                var yDiff = Math.abs(startTouch[yKey] - currentTouch[yKey]);
 
                 if (started) {
                     event.preventDefault();
                 }
 
-				var xDiff = Math.abs(startTouch[xKey] - currentTouch[xKey]);
-				var yDiff = Math.abs(startTouch[yKey] - currentTouch[yKey]);
-				
                 if (yDiff > 10 && yDiff > xDiff && !started) {
                     $(document).off('touchmove.jcarouselSwipe mousemove.jcarouselSwipe');
                     return;
                 }
 
-                if (!animated && xDiff > 10 && xDiff > yDiff) {
+                if (!animated && xDiff > 10 || started) {
                     delta = startTouch[xKey] - currentTouch[xKey];
 
                     if (!started) {
@@ -104,6 +103,7 @@
                 currentTouch = getTouches(event);
                 var xDiff = Math.abs(startTouch[xKey] - currentTouch[xKey]);
                 var yDiff = Math.abs(startTouch[yKey] - currentTouch[yKey]);
+
                 if (started || (!self._options.draggable && xDiff > 10 && xDiff > yDiff)) {
                     var newTarget = self._getNewTarget(startTouch[xKey] - currentTouch[xKey] > 0);
                     newTarget = self._instance._options.wrap === 'circular' ? newTarget.relative : newTarget.static;

--- a/src/jquery.jcarousel-swipe.js
+++ b/src/jquery.jcarousel-swipe.js
@@ -99,7 +99,9 @@
             function dragEnd(event) {
                 event = event.originalEvent || event || window.event;
                 currentTouch = getTouches(event);
-                if (started || (!self._options.draggable && Math.abs(startTouch[xKey] - currentTouch[xKey]) > 10)) {
+                var xDiff = Math.abs(startTouch[xKey] - currentTouch[xKey]);
+                var yDiff = Math.abs(startTouch[yKey] - currentTouch[yKey]);
+                if (started || (!self._options.draggable && xDiff > 10 && xDiff > yDiff)) {
                     var newTarget = self._getNewTarget(startTouch[xKey] - currentTouch[xKey] > 0);
                     newTarget = self._instance._options.wrap === 'circular' ? newTarget.relative : newTarget.static;
 


### PR DESCRIPTION
-> only swipe when swipe vector is within the coordinates diagonals.

This is useful if you have scrollable containers on your carousel "pages" that need to be scrollable in y-direction themselves. It was very hard to scroll without initiating a swipe on the jcarousel.